### PR TITLE
chore: clean up pre-existing ruff findings

### DIFF
--- a/qtaim_gen/source/core/converter.py
+++ b/qtaim_gen/source/core/converter.py
@@ -15,7 +15,6 @@ from glob import glob
 import numpy as np
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from copy import deepcopy
 from typing import Dict, List, Tuple, Union, Any, Optional
 import bisect
 import logging
@@ -29,7 +28,6 @@ from qtaim_embed.data.processing import (
 from qtaim_embed.core.molwrapper import MoleculeWrapper
 from qtaim_embed.utils.grapher import get_grapher
 from qtaim_embed.data.lmdb import serialize_graph, load_graph_from_serialized
-serial_func = serialize_graph
 
 from qtaim_gen.source.utils.lmdbs import (
     get_elements_from_structure_lmdb,
@@ -46,6 +44,8 @@ from qtaim_gen.source.core.qtaim_embed import (
     get_include_exclude_indices,
     build_and_featurize_graph,
 )
+
+serial_func = serialize_graph
 
 
 def clean_id(key: bytes) -> str:
@@ -190,7 +190,7 @@ class Converter:
         if self.total_shards > 1:
             self.logger.info(f"Sharding enabled: shard {self.shard_index + 1} of {self.total_shards}")
             if self.auto_merge and self.shard_index == self.total_shards - 1:
-                self.logger.info(f"Auto-merge enabled: will merge all shards after processing")
+                self.logger.info("Auto-merge enabled: will merge all shards after processing")
 
         ####################### Element Set ########################
         if "element_set" in self.config_dict.keys():
@@ -904,7 +904,7 @@ class Converter:
             merged_feature_scaler = merge_scalers(scalers, features_tf=True, finalize_merged=True)
             feature_out = os.path.join(output_dir, "feature_scaler_iterative.pt")
             merged_feature_scaler.save_scaler(feature_out)
-            logger.info(f"Saved merged feature scaler")
+            logger.info("Saved merged feature scaler")
         else:
             logger.warning("No feature scalers found")
             merged_feature_scaler = None
@@ -927,7 +927,7 @@ class Converter:
             merged_label_scaler = merge_scalers(scalers, features_tf=False, finalize_merged=True)
             label_out = os.path.join(output_dir, "label_scaler_iterative.pt")
             merged_label_scaler.save_scaler(label_out)
-            logger.info(f"Saved merged label scaler")
+            logger.info("Saved merged label scaler")
         else:
             logger.warning("No label scalers found")
             merged_label_scaler = None
@@ -1030,7 +1030,7 @@ class BaseConverter(Converter):
             bonds = value_structure["bonds"]
             bond_list = {tuple(sorted(b)): None for b in bonds if b[0] != b[1]}
             id = clean_id(key) if self.single_lmdb_in else key_str
-        except Exception as e:
+        except Exception:
             failures["structure"].append(key_str)
             return (key_str, None, failures)
 
@@ -1049,7 +1049,7 @@ class BaseConverter(Converter):
                 exclude_locs=index_dict["exclude_locs"],
             )
             return (key_str, graph, failures)
-        except Exception as e:
+        except Exception:
             failures["graph"].append(key_str)
             return (key_str, None, failures)
 
@@ -1265,7 +1265,7 @@ class QTAIMConverter(Converter):
             bond_feats = {}
             atom_feats = {i: {} for i in range(global_feats["n_atoms"])}
             id = clean_id(key) if self.single_lmdb_in else key_str
-        except Exception as e:
+        except Exception:
             failures["structure"].append(key_str)
             return (key_str, None, failures)
 
@@ -1280,7 +1280,7 @@ class QTAIMConverter(Converter):
                 atom_keys=self.keys_data["atom"],
                 bond_keys=self.keys_data["bond"],
             )
-        except Exception as e:
+        except Exception:
             failures["qtaim"].append(key_str)
             return (key_str, None, failures)
 
@@ -1299,7 +1299,7 @@ class QTAIMConverter(Converter):
                 exclude_locs=index_dict["exclude_locs"],
             )
             return (key_str, graph, failures)
-        except Exception as e:
+        except Exception:
             failures["graph"].append(key_str)
             return (key_str, None, failures)
 

--- a/qtaim_gen/source/scripts/json_to_lmdb.py
+++ b/qtaim_gen/source/scripts/json_to_lmdb.py
@@ -116,13 +116,13 @@ class ConversionStats:
             logger.info(f"  LMDB write time: {self.lmdb_write_time_sec:.2f}s ({self.write_rate_files_per_sec:.1f} files/sec)")
 
         if self.missing_keys:
-            logger.warning(f"  Missing keys (top 10):")
+            logger.warning("  Missing keys (top 10):")
             sorted_keys = sorted(self.missing_keys.items(), key=lambda x: -x[1])[:10]
             for key, count in sorted_keys:
                 logger.warning(f"    - '{key}': {count} occurrences")
 
         if self.failed_files and logger.isEnabledFor(logging.DEBUG):
-            logger.debug(f"  Failed files:")
+            logger.debug("  Failed files:")
             for f in self.failed_files[:20]:  # Limit to first 20
                 logger.debug(f"    - {f}")
             if len(self.failed_files) > 20:
@@ -648,7 +648,7 @@ def convert_structure(
     move_files: bool,
 ) -> None:
     """Convert ORCA .inp files to structure LMDB (legacy interface)."""
-    print(f"Converting structure from .inp files...")
+    print("Converting structure from .inp files...")
     inp_files_2_lmdbs(
         root_dir=root_dir,
         out_dir=out_dir,
@@ -924,10 +924,10 @@ def main():
     if total_shards > 1:
         logger.info(f"Sharding:            Shard {shard_index} of {total_shards}")
         if auto_merge and shard_index == total_shards - 1:
-            logger.info(f"Auto-merge:          Enabled (last shard will merge)")
+            logger.info("Auto-merge:          Enabled (last shard will merge)")
         logger.info(f"Assigned folders:    {len(shard_folders) if shard_folders else 0}")
     if args.clean_output:
-        logger.info(f"Clean output:        Yes (removed existing LMDBs)")
+        logger.info("Clean output:        Yes (removed existing LMDBs)")
     if debug_limit:
         logger.info(f"DEBUG MODE:          Limited to {debug_limit} folders")
     logger.info("")

--- a/qtaim_gen/source/utils/lmdbs.py
+++ b/qtaim_gen/source/utils/lmdbs.py
@@ -439,7 +439,6 @@ def parse_config_gen_to_embed(
         Dict[str, Any]]:
             - A dictionary containing the configuration parameters.
     """
-    lmdb_dict = {}
     with open(config_path, "r") as f:
         config_dict = json.load(f)
     config_dict["restart"] = restart

--- a/tests/test_general_converter_filters.py
+++ b/tests/test_general_converter_filters.py
@@ -10,11 +10,8 @@ This test verifies that:
 6. filter_bond_feats utility works correctly
 """
 
-import os
 import pytest
-import json
 from pathlib import Path
-from copy import deepcopy
 
 from qtaim_gen.source.core.converter import GeneralConverter
 from qtaim_gen.source.utils.lmdbs import (

--- a/tests/test_lmdb.py
+++ b/tests/test_lmdb.py
@@ -4,7 +4,6 @@ import os
 import lmdb
 import json
 import pickle as pkl
-import numpy as np
 from copy import deepcopy
 from glob import glob
 from qtaim_gen.source.utils.lmdbs import json_2_lmdbs, inp_files_2_lmdbs, filter_bond_feats
@@ -24,13 +23,11 @@ from qtaim_gen.source.utils.lmdbs import (
 from qtaim_gen.source.scripts.json_to_lmdb import (
     partition_folders_by_shard,
     merge_shards,
-    convert_json_with_stats,
 )
 import logging
 import shutil
 import tempfile
 
-import pytest
 
 
 class TestLMDB:
@@ -830,7 +827,7 @@ class TestConverters:
         filtered_bond_feats_qtaim = _check_filter_bond_feats(connected_bond_paths, normalized_connected_paths)
         filtered_bond_feats_fuzzy = _check_filter_bond_feats(bond_list_fuzzy, normalized_fuzzy)
         filtered_bond_feats_ibsi = _check_filter_bond_feats(bond_list_ibsi, normalized_ibsi)
-        filtered_bond_feats_struct = _check_filter_bond_feats(bond_list, normalized_struct)
+        _check_filter_bond_feats(bond_list, normalized_struct)
 
 
         # check the number of features of each bond that is filtered 
@@ -1122,7 +1119,6 @@ class TestSharding:
         os.makedirs(test_out_dir, exist_ok=True)
 
         # Simulate the naming scheme used in json_to_lmdb.py
-        total_shards = 2
         shard_index = 0
 
         # With sharding, output goes to subdirectory


### PR DESCRIPTION
## Summary

Clears the 25 ruff findings that were sitting on `main` across the converter / json_to_lmdb / lmdbs / test_lmdb / test_general_converter_filters surface area. Behavior unchanged.

## What changed

**20 auto-fixable (via `ruff check --fix`):**
- **F401** — drop unused imports (`os`, `json`, `copy.deepcopy`, `numpy`, `convert_json_with_stats`, redefined `pytest`).
- **F541** — drop the `f` prefix on f-strings with no `{}` placeholders (json_to_lmdb.py x5, converter.py x3).
- **F841 (auto-fixable subset)** — remove the bound name on `except Exception as e:` where `e` is never referenced (converter.py x5).

**5 manual fixes:**
- **E402 x2 in converter.py** — move `serial_func = serialize_graph` below the remaining top-level imports so the file leads with imports only.
- **F841 in lmdbs.py:442** — drop the unused `lmdb_dict = {}` initializer in the config-parser helper.
- **F841 in test_lmdb.py:830** — stop binding the return value of `_check_filter_bond_feats(bond_list, normalized_struct)` since the call is for its internal assertions.
- **F841 in test_lmdb.py:1122** — drop the unused `total_shards = 2` line in `test_sharding_with_chunking_compatibility` (only `shard_index` is actually referenced).

## Verification

- `ruff check` on the touched files: **All checks passed!**
- `pytest -q`: **549 passed, 3 skipped, 0 failed** (~6m20s).

## Coordination with PR #27

This branch is off `main`, so it's independent of [PR #27](https://github.com/santi921/qtaim_generator/pull/27) (the orca feature). Whichever lands first, the other rebases cleanly — the only conflict surface is a couple of imports in `tests/test_general_converter_filters.py` that PR #27 re-uses (`os` re-added there because the orca integration test calls `os.sep`), which git will auto-resolve as an additive merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)