### PR TITLE
feat: timings.json -> timings.lmdb in json2lmdb pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ qtaim_gen/source/
 **Full analysis:** `full-runner`, `full-runner-parsl`, `full-runner-parsl-alcf`
 
 **JSON → LMDB → Graphs (ML pipeline):**
-1. `json-to-lmdb` → Convert parsed JSON outputs to typed LMDB files (structure, charge, qtaim, bond, fuzzy, orca)
+1. `json-to-lmdb` → Convert parsed JSON outputs to typed LMDB files (structure, charge, qtaim, bond, fuzzy, other, orca, timings)
 2. `generator-to-embed` → Run a converter (Base/QTAIM/General) to build DGL graph LMDBs for `qtaim_embed`
 3. `generator-to-embed --split` → Optionally split output into train/val/test LMDBs with train-only scaler fitting
 
@@ -154,7 +154,7 @@ Scripts expect a two-level hierarchy: `root_dir/category/subset/job/`. Each job 
 - `*.wfn`/`*.gbw` (wavefunctions)
 - `charge.json`, `bond.json`, `qtaim.json` (outputs)
 - `orca.json` (ORCA .out parsed properties - energies, orbitals, charges, gradient, quality-filter fields). Converted to `orca.lmdb` by `json-to-lmdb` and consumed by `GeneralConverter` via `orca_lmdb` (data_input `"orca"`, optional `orca_filter`). See `parse_orca_data` in `utils/lmdbs.py` and `DEFAULT_ORCA_FILTER` for the conservative globals-only default.
-- `timings.json`, `.processing.lock`
+- `timings.json` (raw `{step: seconds}` dict; converted to `timings.lmdb` by `json-to-lmdb` as a provenance LMDB — not consumed by any converter), `.processing.lock`
 
 ## External Dependencies
 

--- a/qtaim_gen/source/scripts/json_to_lmdb.py
+++ b/qtaim_gen/source/scripts/json_to_lmdb.py
@@ -160,7 +160,7 @@ def setup_logging(verbose: bool = False, log_file: Optional[str] = None) -> logg
 
 
 # Valid data types for JSON conversion
-JSON_DATA_TYPES = ["charge", "qtaim", "bond", "fuzzy_full", "other", "orca"]
+JSON_DATA_TYPES = ["charge", "qtaim", "bond", "fuzzy_full", "other", "orca", "timings"]
 
 # Default output LMDB names
 DEFAULT_LMDB_NAMES = {
@@ -171,6 +171,7 @@ DEFAULT_LMDB_NAMES = {
     "fuzzy_full": "fuzzy.lmdb",
     "other": "other.lmdb",
     "orca": "orca.lmdb",
+    "timings": "timings.lmdb",
 }
 
 
@@ -700,6 +701,7 @@ def main():
             fuzzy_full  Convert fuzzy_full.json files
             other       Convert other.json files
             orca        Convert orca.json files (parsed ORCA .out properties)
+            timings     Convert timings.json files (raw {step: seconds} dicts; provenance only)
 
             Examples:
             # Convert all data types with defaults
@@ -742,7 +744,7 @@ def main():
         "--types",
         type=str,
         nargs="+",
-        choices=["structure", "charge", "qtaim", "bond", "fuzzy_full", "other", "orca"],
+        choices=["structure", "charge", "qtaim", "bond", "fuzzy_full", "other", "orca", "timings"],
         help="Data types to convert (use --all for all types)",
     )
 

--- a/tests/test_lmdb.py
+++ b/tests/test_lmdb.py
@@ -1302,6 +1302,48 @@ class TestJsonToLmdbOrca:
         env.close()
 
 
+class TestJsonToLmdbTimings:
+    """Smoke test: json_2_lmdbs produces timings.lmdb keyed by folder name with raw dicts."""
+
+    from pathlib import Path
+    src_root = Path(__file__).parent / "test_files" / "lmdb_tests"
+
+    def test_json_2_lmdbs_timings_smoke(self, tmp_path):
+        staging = tmp_path / "jobs"
+        staging.mkdir()
+        for name in ("orca5_rks", "orca6_rks"):
+            dst = staging / name
+            dst.mkdir()
+            shutil.copy(self.src_root / name / "timings.json", dst / "timings.json")
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        json_2_lmdbs(
+            root_dir=str(staging) + os.sep,
+            out_dir=str(out_dir) + os.sep,
+            data_type="timings",
+            out_lmdb="timings.lmdb",
+            chunk_size=10,
+            clean=True,
+            merge=True,
+            move_files=False,
+        )
+
+        lmdb_path = out_dir / "timings.lmdb"
+        assert lmdb_path.exists(), "timings.lmdb was not produced"
+        env = lmdb.open(str(lmdb_path), subdir=False, readonly=True, lock=False)
+        with env.begin() as txn:
+            keys = sorted(k.decode() for k, _ in txn.cursor() if k.decode() != "length")
+            assert keys == ["orca5_rks", "orca6_rks"], f"unexpected keys: {keys}"
+            sample = pkl.loads(txn.get(b"orca5_rks"))
+            assert isinstance(sample, dict), f"expected dict payload, got {type(sample)}"
+            assert "qtaim" in sample, f"expected 'qtaim' key in timings dict, got {list(sample.keys())}"
+            assert isinstance(sample["qtaim"], (int, float)), \
+                f"expected numeric value for 'qtaim', got {type(sample['qtaim'])}"
+        env.close()
+
+
 class TestOrcaDoubleDipWarning:
     """Ensure GeneralConverter warns when both charge_filter and orca_filter are set."""
 


### PR DESCRIPTION
## Summary
- Adds `timings` as a typed LMDB output of `json-to-lmdb`. Each entry: key = job folder name, value = unmodified `timings.json` dict (`{step: seconds}`).
- Provenance/diagnostics only. No converter wiring, no schema flattening, no filter constants.
- Stacks on top of #27 (orca PR), since both touch `JSON_DATA_TYPES` / `DEFAULT_LMDB_NAMES`. Will retarget to main once #27 merges.

## Changes
- `qtaim_gen/source/scripts/json_to_lmdb.py`: adds `"timings"` to `JSON_DATA_TYPES`, `DEFAULT_LMDB_NAMES`, `--types` argparse choices, and `--help` epilog.
- `tests/test_lmdb.py`: new `TestJsonToLmdbTimings::test_json_2_lmdbs_timings_smoke` (uses fixtures already in `tests/test_files/lmdb_tests/`).
- `CLAUDE.md`: pipeline list + Job Folder Layout note.

## Test plan
- [x] `pytest tests/test_lmdb.py::TestJsonToLmdbTimings -v` (1/1 pass)
- [x] `pytest tests/test_lmdb.py -v` (34/34 pass, no regressions on adjacent classes)
- [x] CLI smoke: `json-to-lmdb --root_dir <jobs> --out_dir <out> --types timings orca` produces both `timings.lmdb` and `orca.lmdb`
- [x] CLI smoke: `--types timings` alone produces just `timings.lmdb`