### PR TITLE
feat: --folder_list mode for jagged hierarchies in json-to-lmdb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,8 @@ qtaim_gen/source/
 2. `generator-to-embed` → Run a converter (Base/QTAIM/General) to build DGL graph LMDBs for `qtaim_embed`
 3. `generator-to-embed --split` → Optionally split output into train/val/test LMDBs with train-only scaler fitting
 
+**Jagged hierarchies (e.g. OMol4M):** datasets where job folders sit at variable depth under root must use `json-to-lmdb --folder_list FILE`, where FILE is one absolute job-folder path per line (blanks and `#` comments skipped). LMDB keys become `relpath(folder, root_dir).replace(os.sep, "__")` — e.g. `solvated_protein__outputs_240923__spf_1195777_0_1__step0`. Same key formula across every data type, so downstream LMDBs always join. Internal sharding by `--shard_index/--total_shards` partitions the list by line index modulo total — no external `split` needed. Mutually exclusive with the legacy flat-glob discovery.
+
 ## Converter System
 
 The converter classes in `core/converter.py` transform raw LMDB data into DGL heterographs:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Generator
 
-<img src="https://github.com/santi921/qtaim_generator/blob/main/qtaim_gen/notebooks/TOC.png" width=50% height=50%>
+<img src="https://github.com/santi921/qtaim_generator/blob/main/qtaim_gen/assets/TOC.png" width=50% height=50%>
 
 A package to perform post-processing on molecules, reactions, and (soon) periodic systems. It's a wrapper around Multiwfn that handles high-throughput workflows and can compute a rich set of descriptors including QTAIM, partial charges, several bonding schemes, etc. I am currently overhauling the package away from being QTAIM-first and instead integrating many descriptors in tandem. I will be sticking with the JSON file format for QTAIM and the "full" feature implementations so running calculations will remain the same, gathering and parsing utilities for ML, however, will change. Here's a quick status about what is available for QTAIM/full at the moment:
 
@@ -15,8 +15,7 @@ A package to perform post-processing on molecules, reactions, and (soon) periodi
 - [ ] Reaction-level feature generation and processing
 - [x] High-throughput runners using python MP
 - [x] High-throughput runners using parsl 
-- [ ] Post-processing to LMDBs for ML (ongoing)
-- [ ] Quacc integration (ongoing)
+- [x] Post-processing to LMDBs for ML (ongoing)
 
 
 Simply install this package by cloning the repo and running: 
@@ -94,6 +93,17 @@ json-to-lmdb --file jobs.pkl --root /path/to/job_folders --out /path/to/lmdbs --
 ```
 
 See `docs/SHARDING_GUIDE.md` for details on sharded conversion and merging.
+
+For datasets with jagged hierarchies (job folders at variable depths, e.g. OMol4M), pass a list of absolute job-folder paths via `--folder_list`. LMDB keys are derived from each folder's relpath under `--root_dir` with `os.sep` replaced by `__` (e.g. `solvated_protein__outputs_240923__spf_1195777_0_1__step0`). Internal sharding partitions the list by line index:
+
+```bash
+# One shard per submission (last shard auto-merges):
+json-to-lmdb --root_dir /p/lustre5/.../omol/ --out_dir /p/lustre5/.../converters/omol/ \
+             --folder_list /path/to/job_paths.txt \
+             --all --move_files \
+             --shard_index 0 --total_shards 6
+# ...repeat for shard_index 1..5; add --auto_merge to the last one.
+```
 
 ### Step 2: LMDB → PyG Heterographs
 Run a converter to build graph LMDBs from the typed LMDBs:

--- a/qtaim_gen/source/scripts/json_to_lmdb.py
+++ b/qtaim_gen/source/scripts/json_to_lmdb.py
@@ -53,6 +53,7 @@ from glob import glob
 from typing import Dict, List, Optional, Set, Tuple
 
 from qtaim_gen.source.utils.lmdbs import json_2_lmdbs, inp_files_2_lmdbs
+from qtaim_gen.source.utils.io import sanitize_folders
 
 
 @dataclass
@@ -173,6 +174,42 @@ DEFAULT_LMDB_NAMES = {
     "orca": "orca.lmdb",
     "timings": "timings.lmdb",
 }
+
+
+def read_folder_list(path: str, logger: logging.Logger) -> List[str]:
+    """Read a list of job-folder absolute paths from a text file.
+
+    One path per line. Blank lines and lines starting with '#' are skipped.
+    Existing-directory validation is performed via sanitize_folders.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"--folder_list file not found: {path}")
+    with open(path, "r") as f:
+        raw = [line.strip() for line in f]
+    candidates = [line for line in raw if line and not line.startswith("#")]
+    if not candidates:
+        raise ValueError(f"--folder_list file contained no usable paths: {path}")
+    folders = sanitize_folders(candidates)
+    if not folders:
+        raise ValueError(f"No valid (existing) folders found in {path}")
+    logger.info(f"Read {len(folders)} folder paths from {path}")
+    if len(folders) >= 1:
+        logger.debug(f"  first: {folders[0]}")
+        logger.debug(f"  last:  {folders[-1]}")
+    return folders
+
+
+def partition_list_by_shard(items: List[str], shard_index: int, total_shards: int, logger: logging.Logger) -> List[str]:
+    """Partition a precomputed list across shards by index modulo total_shards.
+
+    No filesystem walk; deterministic and idempotent.
+    """
+    if total_shards <= 1:
+        return list(items)
+    partitioned = [item for i, item in enumerate(items) if i % total_shards == shard_index]
+    logger.info(f"Shard {shard_index}: assigned {len(partitioned)} items (of {len(items)} total)")
+    logger.debug(f"First 5 items in shard {shard_index}: {partitioned[:5]}")
+    return partitioned
 
 
 def partition_folders_by_shard(root_dir: str, shard_index: int, total_shards: int, logger: logging.Logger) -> List[str]:
@@ -422,6 +459,7 @@ def convert_json_with_stats(
     shard_index: int = 0,
     total_shards: int = 1,
     shard_folders: Optional[List[str]] = None,
+    folder_paths: Optional[List[str]] = None,
 ) -> ConversionStats:
     """Convert JSON files with detailed statistics tracking."""
     stats = ConversionStats(data_type=data_type)
@@ -433,8 +471,19 @@ def convert_json_with_stats(
         out_lmdb = f"{base_name}_shard_{shard_index}.lmdb"
         logger.info(f"Sharding enabled: output will be {out_lmdb}")
 
-    # Find files - filter by shard assignment if sharding is enabled
-    if total_shards > 1 and shard_folders:
+    # Find files - folder_paths (jagged) > shard_folders (legacy flat) > full glob
+    if folder_paths is not None:
+        files = []
+        for folder in folder_paths:
+            if move_files:
+                candidate = os.path.join(folder, "generator", f"{data_type}.json")
+            else:
+                candidate = os.path.join(folder, f"{data_type}.json")
+            if os.path.exists(candidate):
+                files.append(candidate)
+        pattern = f"<folder_list>/{data_type}.json"
+        logger.debug(f"Shard {shard_index}: found {len(files)} {data_type}.json files across {len(folder_paths)} folder_list paths")
+    elif total_shards > 1 and shard_folders:
         # Build patterns for assigned folders only
         files = []
         for folder in shard_folders:
@@ -524,7 +573,8 @@ def convert_json_with_stats(
         merge=merge,
         move_files=move_files,
         limit=limit,
-        shard_folders=shard_folders,
+        shard_folders=shard_folders if folder_paths is None else None,
+        folder_paths=folder_paths,
     )
     stats.lmdb_write_time_sec = time.time() - write_start
 
@@ -548,6 +598,7 @@ def convert_structure_with_stats(
     shard_index: int = 0,
     total_shards: int = 1,
     shard_folders: Optional[List[str]] = None,
+    folder_paths: Optional[List[str]] = None,
 ) -> ConversionStats:
     """Convert ORCA .inp files to structure LMDB with statistics."""
     stats = ConversionStats(data_type="structure")
@@ -558,8 +609,15 @@ def convert_structure_with_stats(
         out_lmdb = f"{base_name}_shard_{shard_index}.lmdb"
         logger.info(f"Sharding enabled: output will be {out_lmdb}")
 
-    # Find files - filter by shard assignment if sharding is enabled
-    if total_shards > 1 and shard_folders:
+    # Find files - folder_paths (jagged) > shard_folders (legacy flat) > full glob
+    if folder_paths is not None:
+        files = []
+        for folder in folder_paths:
+            files.extend(glob(os.path.join(folder, "*.inp")))
+        total_found = len(files)
+        pattern = "<folder_list>/*.inp"
+        logger.debug(f"Shard {shard_index}: found {total_found} .inp files across {len(folder_paths)} folder_list paths")
+    elif total_shards > 1 and shard_folders:
         # Build patterns for assigned folders only
         files = []
         for folder in shard_folders:
@@ -628,7 +686,8 @@ def convert_structure_with_stats(
         clean=clean,
         merge=merge,
         limit=limit,
-        shard_folders=shard_folders,
+        shard_folders=shard_folders if folder_paths is None else None,
+        folder_paths=folder_paths,
     )
     stats.lmdb_write_time_sec = time.time() - write_start
 
@@ -838,6 +897,18 @@ def main():
     )
 
     parser.add_argument(
+        "--folder_list",
+        type=str,
+        default=None,
+        help=(
+            "Path to a text file with one absolute job-folder path per line "
+            "(blanks and '#' comments skipped). Required for jagged hierarchies "
+            "(e.g. OMol4M). LMDB keys are derived from each folder's relpath under "
+            "--root_dir, with os.sep replaced by '__'."
+        ),
+    )
+
+    parser.add_argument(
         "--auto_merge",
         action="store_true",
         default=False,
@@ -909,9 +980,13 @@ def main():
         os.makedirs(out_dir, exist_ok=True)
         logger.info(f"Sharding: Creating output subdirectory {out_dir}")
 
-    # Compute shard folder assignments
+    # Compute shard folder assignments. Folder-list mode wins over flat-glob.
     shard_folders = None
-    if total_shards > 1:
+    folder_paths = None
+    if args.folder_list:
+        all_paths = read_folder_list(args.folder_list, logger)
+        folder_paths = partition_list_by_shard(all_paths, shard_index, total_shards, logger)
+    elif total_shards > 1:
         shard_folders = partition_folders_by_shard(root_dir, shard_index, total_shards, logger)
 
     logger.info("=" * 60)
@@ -925,11 +1000,14 @@ def main():
     logger.info(f"Clean intermediate:  {clean}")
     logger.info(f"Generator subfolders: {move_files}")
     logger.info(f"Validation level:    {full_set} ({'baseline' if full_set == 0 else 'extended' if full_set == 1 else 'full'})")
+    if args.folder_list:
+        logger.info(f"Folder list:         {args.folder_list} ({len(folder_paths)} paths assigned to this shard)")
     if total_shards > 1:
         logger.info(f"Sharding:            Shard {shard_index} of {total_shards}")
         if auto_merge and shard_index == total_shards - 1:
             logger.info("Auto-merge:          Enabled (last shard will merge)")
-        logger.info(f"Assigned folders:    {len(shard_folders) if shard_folders else 0}")
+        if shard_folders is not None:
+            logger.info(f"Assigned folders:    {len(shard_folders) if shard_folders else 0}")
     if args.clean_output:
         logger.info("Clean output:        Yes (removed existing LMDBs)")
     if debug_limit:
@@ -959,6 +1037,7 @@ def main():
                     shard_index=shard_index,
                     total_shards=total_shards,
                     shard_folders=shard_folders,
+                    folder_paths=folder_paths,
                 )
             else:
                 stats = convert_json_with_stats(
@@ -976,6 +1055,7 @@ def main():
                     shard_index=shard_index,
                     total_shards=total_shards,
                     shard_folders=shard_folders,
+                    folder_paths=folder_paths,
                 )
 
             all_stats.append(stats)

--- a/qtaim_gen/source/utils/lmdbs.py
+++ b/qtaim_gen/source/utils/lmdbs.py
@@ -1,13 +1,16 @@
 import os
 import lmdb
 import json
+import logging
 import pickle
 from typing import Dict, List, Tuple, Any, Optional, Union
 from glob import glob
 from dataclasses import dataclass
-import numpy as np 
+import numpy as np
 from pymatgen.core import Molecule
 from pymatgen.analysis.graphs import MoleculeGraph
+
+logger = logging.getLogger(__name__)
 
 from qtaim_gen.source.utils.io import (
     get_bonds_from_coords,
@@ -33,10 +36,11 @@ def _derive_lmdb_key(folder_path: str, root_dir: str) -> str:
     norm_root = os.path.normpath(root_dir)
     norm_folder = os.path.normpath(folder_path)
     rel = os.path.relpath(norm_folder, norm_root)
-    if rel.startswith(".."):
-        print(
-            f"Warning: folder '{folder_path}' is not under root_dir '{root_dir}'; "
-            f"using absolute-path key fallback."
+    if rel == ".." or rel.startswith(".." + os.sep):
+        logger.warning(
+            "folder '%s' is not under root_dir '%s'; using absolute-path key fallback.",
+            folder_path,
+            root_dir,
         )
         rel = norm_folder.lstrip(os.sep)
     return rel.replace(os.sep, "__")

--- a/qtaim_gen/source/utils/lmdbs.py
+++ b/qtaim_gen/source/utils/lmdbs.py
@@ -19,6 +19,29 @@ from qtaim_gen.source.core.parse_qtaim import (
 )
 
 
+def _derive_lmdb_key(folder_path: str, root_dir: str) -> str:
+    """Derive a deterministic LMDB key from a job folder path.
+
+    For folder-list mode: key = relpath(folder, root_dir) with os.sep replaced by '__'.
+    Falls back to the absolute path (encoded the same way, leading sep stripped) when
+    the folder is not under root_dir.
+
+    Examples:
+        root='/data/omol/', folder='/data/omol/sub/job/step0' -> 'sub__job__step0'
+        root='/data/foo/',  folder='/elsewhere/job'           -> 'elsewhere__job' (warns)
+    """
+    norm_root = os.path.normpath(root_dir)
+    norm_folder = os.path.normpath(folder_path)
+    rel = os.path.relpath(norm_folder, norm_root)
+    if rel.startswith(".."):
+        print(
+            f"Warning: folder '{folder_path}' is not under root_dir '{root_dir}'; "
+            f"using absolute-path key fallback."
+        )
+        rel = norm_folder.lstrip(os.sep)
+    return rel.replace(os.sep, "__")
+
+
 def convert_inp_to_xyz(orca_path, output_path):
     """
     Convert an ORCA input file to an XYZ file.
@@ -214,10 +237,12 @@ def json_2_lmdbs(
     move_files: Optional[bool] = False,
     limit: Optional[int] = None,
     shard_folders: Optional[List[str]] = None,
+    folder_paths: Optional[List[str]] = None,
 ):
     """Converts folders of output json files to lmdb files.
     Args:
-        root_dir (str): Root directory containing the json files.
+        root_dir (str): Root directory containing the json files (also used as the
+            relpath prefix for key derivation in folder_paths mode).
         out_dir (str): Output directory for the lmdb files.
         data_type (str): Data type to convert. Options are "charge", "bond", "other", "qtaim".
         out_lmdb (str): Output lmdb file.
@@ -225,10 +250,25 @@ def json_2_lmdbs(
         clean (Optional[bool], optional): If True, delete the json files. Defaults to False.
         move_files (Optional[bool], optional): If files were moved into separate ./generator/ folders in each job
         limit (Optional[int], optional): Limit number of files to process (for debugging).
-        shard_folders (Optional[List[str]], optional): If set, only process these folder names (for sharding).
+        shard_folders (Optional[List[str]], optional): If set, only process these folder names (legacy flat-glob mode).
+        folder_paths (Optional[List[str]], optional): If set, iterate this explicit list of job folder
+            paths instead of globbing. LMDB keys are derived from each folder's relpath under root_dir
+            (os.sep replaced by '__'). Use this for jagged hierarchies. Mutually exclusive with shard_folders.
     """
+    if folder_paths is not None and shard_folders is not None:
+        raise ValueError("folder_paths and shard_folders are mutually exclusive")
+
     chunk_ind = 1
-    if shard_folders is not None:
+    if folder_paths is not None:
+        files_target = []
+        for folder in folder_paths:
+            if move_files:
+                candidate = os.path.join(folder, "generator", f"{data_type}.json")
+            else:
+                candidate = os.path.join(folder, f"{data_type}.json")
+            if os.path.exists(candidate):
+                files_target.append(candidate)
+    elif shard_folders is not None:
         # Only glob files from the assigned shard folders
         files_target = []
         for folder in shard_folders:
@@ -253,9 +293,15 @@ def json_2_lmdbs(
         for file in chunk:
             with open(file, "r") as f:
                 data = json.load(f)
-                # When move_files=True, path is root/job/generator/file.json -> use [-3]
-                # When move_files=False, path is root/job/file.json -> use [-2]
-                name = file.split("/")[-3] if move_files else file.split("/")[-2]
+                if folder_paths is not None:
+                    # Folder-list mode: key from full job-folder relpath under root_dir
+                    job_folder = os.path.dirname(os.path.dirname(file)) if move_files else os.path.dirname(file)
+                    name = _derive_lmdb_key(job_folder, root_dir)
+                else:
+                    # Legacy mode: leaf folder name
+                    # When move_files=True, path is root/job/generator/file.json -> use [-3]
+                    # When move_files=False, path is root/job/file.json -> use [-2]
+                    name = file.split("/")[-3] if move_files else file.split("/")[-2]
                 data_dict[name] = data
 
         write_lmdb(data_dict, out_dir, f"{data_type}_{chunk_ind}.lmdb")
@@ -287,20 +333,32 @@ def inp_files_2_lmdbs(
     merge: Optional[bool] = True,
     limit: Optional[int] = None,
     shard_folders: Optional[List[str]] = None,
+    folder_paths: Optional[List[str]] = None,
 ):
     """
     Converts orca inp files into lmdbs at scale.
     Args:
-        root_dir (str): Root directory containing the input files.
+        root_dir (str): Root directory containing the input files (also used as the
+            relpath prefix for key derivation in folder_paths mode).
         out_dir (str): Output directory for the lmdb files.
         out_lmdb (str): Output lmdb file.
         chunk_size (int): Size of the chunks to split the data into.
         clean (Optional[bool], optional): If True, delete the input files. Defaults to False.
         limit (Optional[int], optional): Limit number of files to process (for debugging).
         merge (Optional[bool], optional): If True, merge the lmdb files after creation. Defaults to True.
-        shard_folders (Optional[List[str]], optional): If set, only process these folder names (for sharding).
+        shard_folders (Optional[List[str]], optional): If set, only process these folder names (legacy flat-glob mode).
+        folder_paths (Optional[List[str]], optional): If set, iterate this explicit list of job folder
+            paths instead of globbing. LMDB keys are derived from each folder's relpath under root_dir.
+            Mutually exclusive with shard_folders.
     """
-    if shard_folders is not None:
+    if folder_paths is not None and shard_folders is not None:
+        raise ValueError("folder_paths and shard_folders are mutually exclusive")
+
+    if folder_paths is not None:
+        files = []
+        for folder in folder_paths:
+            files.extend(glob(os.path.join(folder, "*.inp")))
+    elif shard_folders is not None:
         files = []
         for folder in shard_folders:
             files.extend(glob(os.path.join(root_dir, folder, "*.inp")))
@@ -331,7 +389,10 @@ def inp_files_2_lmdbs(
 
             molecule_graph = MoleculeGraph.with_empty_graph(molecule)
 
-            identifier = file.split("/")[-2]
+            if folder_paths is not None:
+                identifier = _derive_lmdb_key(os.path.dirname(file), root_dir)
+            else:
+                identifier = file.split("/")[-2]
 
             # Get bonds directly from coords (no xyz file needed)
             bonds = get_bonds_from_coords(species, coords)

--- a/tests/test_json_to_lmdb_sharding.py
+++ b/tests/test_json_to_lmdb_sharding.py
@@ -17,8 +17,40 @@ from pathlib import Path
 
 from qtaim_gen.source.scripts.json_to_lmdb import (
     partition_folders_by_shard,
+    partition_list_by_shard,
     merge_shards,
 )
+
+
+class TestPartitionListByShard:
+    """List-based shard partitioning (folder_list mode)."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.logger = logging.getLogger("test_partition_list")
+        cls.logger.setLevel(logging.WARNING)
+
+    def test_partition_list_basic(self):
+        items = [f"/path/job_{i}" for i in range(10)]
+        s0 = partition_list_by_shard(items, 0, 3, self.logger)
+        s1 = partition_list_by_shard(items, 1, 3, self.logger)
+        s2 = partition_list_by_shard(items, 2, 3, self.logger)
+        assert s0 == [items[i] for i in [0, 3, 6, 9]]
+        assert s1 == [items[i] for i in [1, 4, 7]]
+        assert s2 == [items[i] for i in [2, 5, 8]]
+
+    def test_partition_list_full_coverage_no_overlap(self):
+        items = [f"/p/{i}" for i in range(50)]
+        n = 7
+        all_assigned = []
+        for shard in range(n):
+            all_assigned.extend(partition_list_by_shard(items, shard, n, self.logger))
+        assert sorted(all_assigned) == sorted(items)
+
+    def test_partition_list_no_sharding(self):
+        items = [f"/p/{i}" for i in range(5)]
+        out = partition_list_by_shard(items, 0, 1, self.logger)
+        assert out == items
 
 
 class TestSharding:

--- a/tests/test_lmdb.py
+++ b/tests/test_lmdb.py
@@ -1542,6 +1542,108 @@ class TestFolderListMode:
                 shard_folders=["b"],
             )
 
+    def test_inp_files_mutual_exclusion(self, tmp_path):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            inp_files_2_lmdbs(
+                root_dir=str(tmp_path) + os.sep,
+                out_dir=str(tmp_path) + os.sep,
+                out_lmdb="x.lmdb",
+                chunk_size=10,
+                folder_paths=["/a"],
+                shard_folders=["b"],
+            )
+
+    def test_json_2_lmdbs_with_folder_paths_move_files(self, tmp_path):
+        """folder_paths + move_files=True: timings.json lives under <folder>/generator/."""
+        root = tmp_path / "root"
+        root.mkdir()
+        layout = [
+            "metal_organics/restart5to6/job_aaa",
+            "solvated_protein/outputs_240923/spf_111/step0",
+        ]
+        folders = []
+        for relpath in layout:
+            d = root / relpath
+            (d / "generator").mkdir(parents=True)
+            (d / "generator" / "timings.json").write_text(
+                json.dumps({"qtaim": 1.0, "other": 2.0})
+            )
+            folders.append(str(d))
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        json_2_lmdbs(
+            root_dir=str(root) + os.sep,
+            out_dir=str(out_dir) + os.sep,
+            data_type="timings",
+            out_lmdb="timings.lmdb",
+            chunk_size=10,
+            clean=True,
+            merge=True,
+            move_files=True,
+            folder_paths=folders,
+        )
+
+        env = lmdb.open(str(out_dir / "timings.lmdb"), subdir=False, readonly=True, lock=False)
+        with env.begin() as txn:
+            keys = sorted(k.decode() for k, _ in txn.cursor() if k.decode() != "length")
+            sample = pkl.loads(txn.get(b"metal_organics__restart5to6__job_aaa"))
+        env.close()
+
+        assert keys == sorted([
+            "metal_organics__restart5to6__job_aaa",
+            "solvated_protein__outputs_240923__spf_111__step0",
+        ])
+        assert sample == {"qtaim": 1.0, "other": 2.0}
+
+
+class TestReadFolderList:
+    """read_folder_list: file-format edge cases."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.logger = logging.getLogger("test_read_folder_list")
+        cls.logger.setLevel(logging.WARNING)
+
+    def test_skips_blanks_and_comments(self, tmp_path):
+        from qtaim_gen.source.scripts.json_to_lmdb import read_folder_list
+
+        d1 = tmp_path / "a"
+        d2 = tmp_path / "b"
+        d1.mkdir()
+        d2.mkdir()
+        list_file = tmp_path / "jobs.txt"
+        list_file.write_text(
+            f"# header comment\n\n{d1}\n   \n# another comment\n{d2}\n\n"
+        )
+        out = read_folder_list(str(list_file), self.logger)
+        assert sorted(out) == sorted([str(d1), str(d2)])
+
+    def test_missing_file_raises(self, tmp_path):
+        from qtaim_gen.source.scripts.json_to_lmdb import read_folder_list
+
+        with pytest.raises(FileNotFoundError):
+            read_folder_list(str(tmp_path / "nope.txt"), self.logger)
+
+    def test_all_blank_or_comments_raises(self, tmp_path):
+        from qtaim_gen.source.scripts.json_to_lmdb import read_folder_list
+
+        list_file = tmp_path / "jobs.txt"
+        list_file.write_text("# only comments\n\n\n# more\n")
+        with pytest.raises(ValueError, match="no usable paths"):
+            read_folder_list(str(list_file), self.logger)
+
+    def test_all_paths_missing_raises(self, tmp_path):
+        from qtaim_gen.source.scripts.json_to_lmdb import read_folder_list
+
+        list_file = tmp_path / "jobs.txt"
+        list_file.write_text(
+            f"{tmp_path}/does_not_exist_1\n{tmp_path}/does_not_exist_2\n"
+        )
+        with pytest.raises(ValueError, match="No valid"):
+            read_folder_list(str(list_file), self.logger)
+
 
 # create dummy to just run test_parsers and setups
 

--- a/tests/test_lmdb.py
+++ b/tests/test_lmdb.py
@@ -1430,6 +1430,119 @@ class TestOrcaDoubleDipWarning:
         )
 
 
+class TestFolderListMode:
+    """folder_paths mode: jagged hierarchies, __-joined relpath keys."""
+
+    from pathlib import Path
+    src_root = Path(__file__).parent / "test_files" / "lmdb_tests"
+
+    @staticmethod
+    def _build_jagged_tree(root):
+        """Create 4 job folders at mixed depths under root, each with timings.json + orca.inp."""
+        layout = [
+            ("metal_organics/restart5to6/job_aaa",),
+            ("solvated_protein/outputs_240923/spf_111/step0",),
+            ("solvated_protein/outputs_240923/spf_111/step1",),
+            ("electrolytes/md_based/outputs_241029/sample_xyz/step2",),
+        ]
+        folders = []
+        for (relpath,) in layout:
+            d = root / relpath
+            d.mkdir(parents=True)
+            (d / "timings.json").write_text(json.dumps({"qtaim": 1.5, "other": 2.5}))
+            shutil.copy(
+                TestFolderListMode.src_root / "orca5_rks" / "orca.inp",
+                d / "orca.inp",
+            )
+            folders.append(str(d))
+        return folders
+
+    def test_json_2_lmdbs_with_folder_paths_jagged(self, tmp_path):
+        root = tmp_path / "root"
+        root.mkdir()
+        folders = self._build_jagged_tree(root)
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        json_2_lmdbs(
+            root_dir=str(root) + os.sep,
+            out_dir=str(out_dir) + os.sep,
+            data_type="timings",
+            out_lmdb="timings.lmdb",
+            chunk_size=10,
+            clean=True,
+            merge=True,
+            move_files=False,
+            folder_paths=folders,
+        )
+
+        lmdb_path = out_dir / "timings.lmdb"
+        assert lmdb_path.exists()
+        env = lmdb.open(str(lmdb_path), subdir=False, readonly=True, lock=False)
+        with env.begin() as txn:
+            keys = sorted(k.decode() for k, _ in txn.cursor() if k.decode() != "length")
+        env.close()
+
+        expected = sorted([
+            "metal_organics__restart5to6__job_aaa",
+            "solvated_protein__outputs_240923__spf_111__step0",
+            "solvated_protein__outputs_240923__spf_111__step1",
+            "electrolytes__md_based__outputs_241029__sample_xyz__step2",
+        ])
+        assert keys == expected, f"unexpected keys: {keys}"
+
+    def test_inp_files_2_lmdbs_with_folder_paths_jagged(self, tmp_path):
+        root = tmp_path / "root"
+        root.mkdir()
+        folders = self._build_jagged_tree(root)
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        inp_files_2_lmdbs(
+            root_dir=str(root) + os.sep,
+            out_dir=str(out_dir) + os.sep,
+            out_lmdb="structure.lmdb",
+            chunk_size=10,
+            clean=True,
+            merge=True,
+            folder_paths=folders,
+        )
+
+        lmdb_path = out_dir / "structure.lmdb"
+        assert lmdb_path.exists()
+        env = lmdb.open(str(lmdb_path), subdir=False, readonly=True, lock=False)
+        with env.begin() as txn:
+            keys = sorted(k.decode() for k, _ in txn.cursor() if k.decode() != "length")
+            sample = pkl.loads(txn.get(b"metal_organics__restart5to6__job_aaa"))
+        env.close()
+
+        assert "metal_organics__restart5to6__job_aaa" in keys
+        assert "solvated_protein__outputs_240923__spf_111__step0" in keys
+        assert "solvated_protein__outputs_240923__spf_111__step1" in keys
+        assert "molecule" in sample
+        assert sample["ids"] == "metal_organics__restart5to6__job_aaa"
+
+    def test_derive_lmdb_key_handles_path_outside_root(self):
+        from qtaim_gen.source.utils.lmdbs import _derive_lmdb_key
+
+        key = _derive_lmdb_key("/abs/elsewhere/job", "/different/root")
+        assert "__" in key
+        assert "elsewhere" in key
+        assert "job" in key
+
+    def test_folder_paths_and_shard_folders_mutually_exclusive(self, tmp_path):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            json_2_lmdbs(
+                root_dir=str(tmp_path) + os.sep,
+                out_dir=str(tmp_path) + os.sep,
+                data_type="timings",
+                out_lmdb="x.lmdb",
+                chunk_size=10,
+                folder_paths=["/a"],
+                shard_folders=["b"],
+            )
+
+
 # create dummy to just run test_parsers and setups
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds support for datasets where job folders sit at **variable depth** under the root (e.g. OMol4M ~1.4M jobs at 3-5 levels deep). Pass `--folder_list FILE` with one absolute job-folder path per line; sharding is internal (line-index modulo `--total_shards`), no external `split` step needed.

LMDB keys are `relpath(folder, root_dir).replace(os.sep, "__")` — same formula across every data type, so all output LMDBs join cleanly downstream.

Stacks on #29 (timings) and #27 (orca). Will retarget once those merge.

## Changes
- `utils/lmdbs.py`: new `_derive_lmdb_key` helper. `json_2_lmdbs` and `inp_files_2_lmdbs` gain `folder_paths` kwarg (mutually exclusive with `shard_folders`).
- `scripts/json_to_lmdb.py`: new `--folder_list FILE` CLI arg; new helpers `read_folder_list` (uses existing `sanitize_folders`) and `partition_list_by_shard` (pure modulo, no fs walk).
- `tests/test_lmdb.py`: `TestFolderListMode` — jagged-tree fixture (4 folders at mixed depths), tests for json + inp paths, fallback for paths outside root, mutual-exclusion ValueError.
- `tests/test_json_to_lmdb_sharding.py`: `TestPartitionListByShard` — basic partition, full coverage with no overlap, no-shard passthrough.
- Docs in `CLAUDE.md` and `README.md`.

## Backward compatibility
When `--folder_list` is unset, behavior is unchanged. Legacy flat-glob discovery and leaf-folder-name keys are preserved. All existing tests pass.

## Test plan
- [x] `pytest tests/test_lmdb.py::TestFolderListMode -v` (4/4 pass)
- [x] `pytest tests/test_json_to_lmdb_sharding.py::TestPartitionListByShard -v` (3/3 pass)
- [x] Full lmdb + sharding suites: 54/54 pass (all backward-compat tests still green)
- [x] Full project suite (excluding pre-existing `test_parse_orca::TestEmptyBondSections` missing-fixture failure): 553 passed
- [x] End-to-end CLI smoke: `--folder_list` with 3 jagged-depth folders produces `timings.lmdb`, `orca.lmdb`, `structure.lmdb` all keyed with `__`-joined relpaths (`a__deep__job1`, `b__job2`, `c__d__e__job3`)

## OMol4M usage example
```bash
json-to-lmdb \
  --root_dir /p/lustre5/bennion1/Omol2025-4M-DiversitySet/omol/ \
  --out_dir  /p/lustre5/vargas58/converters/omol/ \
  --folder_list /path/to/omol_job_paths.txt \
  --all --move_files \
  --shard_index 0 --total_shards 6
# repeat shards 1..5; add --auto_merge to the last
```