### PR TITLE
Feat/multi vertical 4m scale

### DIFF
--- a/qtaim_gen/source/core/converter.py
+++ b/qtaim_gen/source/core/converter.py
@@ -127,6 +127,39 @@ def load_scaler(scaler_path: str, features_tf: bool):
     )
 
 
+def _validate_and_log_scaler(scaler, name, logger):
+    """Log per-node-type std stats and raise on a degenerate std.
+
+    A zero std divides by zero at apply time (Inf); a non-finite std means a
+    raw feature contained NaN/Inf and poisoned the fit. Either silently
+    corrupts every scaled graph, so surface it here before applying.
+    """
+    import torch
+
+    bad = []
+    for nt, std in scaler._std.items():
+        finite = torch.isfinite(std)
+        n_zero = int((std == 0).sum())
+        n_bad = int((~finite).sum())
+        if bool(finite.any()):
+            smin = float(std[finite].min())
+            smax = float(std[finite].max())
+        else:
+            smin = smax = float("nan")
+        logger.info(
+            f"{name} scaler [{nt}]: dim={std.numel()} std_min={smin:.3e} "
+            f"std_max={smax:.3e} zeros={n_zero} nonfinite={n_bad}"
+        )
+        if n_zero or n_bad:
+            bad.append(f"{nt} (zeros={n_zero}, nonfinite={n_bad})")
+    if bad:
+        raise RuntimeError(
+            f"{name} scaler has degenerate std for: {', '.join(bad)}. "
+            "Refusing to apply (would write Inf/NaN). This indicates a broken "
+            "scaler merge or NaN/Inf in raw features."
+        )
+
+
 class Converter:
     def __init__(self, config_dict: Dict[str, Any], config_path: str = None):
         self.config_dict = config_dict
@@ -975,6 +1008,13 @@ class Converter:
             logger.warning("No label scalers found")
             merged_label_scaler = None
 
+        # Validate merged scalers before applying: a zero or non-finite std
+        # would silently write Inf/NaN into every graph. Fail loudly instead.
+        if merged_feature_scaler is not None:
+            _validate_and_log_scaler(merged_feature_scaler, "feature", logger)
+        if merged_label_scaler is not None:
+            _validate_and_log_scaler(merged_label_scaler, "label", logger)
+
         # Apply scalers to merged LMDB
         if not skip_scaling and merged_feature_scaler and merged_label_scaler:
             logger.info("Applying merged scalers to LMDB...")
@@ -1010,6 +1050,7 @@ class Converter:
                         count += 1
                     except Exception as e:
                         logger.warning(f"Failed to scale graph {key}: {e}")
+                txn.put(b"scaled", pickle.dumps(True, protocol=-1))
             env.close()
             logger.info(f"Applied scalers to {count} graphs")
 

--- a/qtaim_gen/source/core/omol.py
+++ b/qtaim_gen/source/core/omol.py
@@ -779,7 +779,11 @@ def parse_multiwfn(
         if file.endswith(".out"):
             file_full_path = os.path.join(folder, file)
             for routine in routine_list:
-                if routine in file:
+                # Exact filename match: substring matching double-parsed
+                # becke_fuzzy_density.out under both 'becke' and
+                # 'becke_fuzzy_density' (same for mbis/*_spin variants),
+                # writing wrong-parser output that only list order corrected.
+                if file == routine + ".out":
                     json_file = file_full_path.replace(".out", ".json")
                     try:
                         if routine == "fuzzy_full":

--- a/qtaim_gen/source/core/omol.py
+++ b/qtaim_gen/source/core/omol.py
@@ -1646,18 +1646,33 @@ _STEP_COMPLETION_MARKERS = {
 }
 
 
+# Generic completion signal: multiwfn prints this banner once at startup and
+# once more when the .mfwn script's final "0" returns to the main menu before
+# "q". Every generated script is single-module (enter module -> compute ->
+# print results -> "0" -> "q"), so a second occurrence proves the routine
+# finished writing its results. A run killed mid-computation (walltime, OOM)
+# dies in a progress loop and never reaches the second print. Verified on
+# Multiwfn 3.8 noGUI: 12/12 complete .outs contain it twice, truncated .outs
+# once (see docs re: elytes 274-atom edge case, Jul 2026).
+_MULTIWFN_MENU_BANNER = b"Main function menu"
+_MENU_BANNER_REQUIRED_COUNT = 2
+
+
 def _is_substantive_step_out(path: str, order: str = None) -> bool:
-    """True if a multiwfn/orca_2mkl .out file looks like a successful run.
+    """True if a multiwfn .out file looks like a successful run.
 
     Rejects empty files and any file whose first 8 KB contains one of the
     multiwfn error signatures. Both signatures appear early in the file
-    (banner + first prompt loop), so a single bounded read catches them and
-    keeps cost flat on large CPprop outputs.
+    (banner + first prompt loop), so a single bounded read catches them.
 
-    For routines in `_STEP_COMPLETION_MARKERS`, additionally requires that
-    the .out tail contains the routine's positive completion marker. This
-    catches walltime-killed runs whose head looks clean but whose result
-    section was never reached.
+    Completion is detected generically via `_MULTIWFN_MENU_BANNER`: the
+    main-menu banner must appear at least `_MENU_BANNER_REQUIRED_COUNT`
+    times (startup print + the script's final return-to-main-menu). This
+    catches walltime-killed runs for every routine, whose head looks clean
+    but whose result section was never reached.
+
+    Routines in `_STEP_COMPLETION_MARKERS` must additionally contain their
+    positive result-section marker.
     """
     if not os.path.isfile(path):
         return False
@@ -1673,22 +1688,32 @@ def _is_substantive_step_out(path: str, order: str = None) -> bool:
         return False
 
     marker = _STEP_COMPLETION_MARKERS.get(order)
-    if marker is None:
-        return True
+    marker_bytes = marker.encode("utf-8") if marker is not None else None
 
-    # Marker may live anywhere past the head; scan the whole file but cheaply.
-    if marker in head:
-        return True
+    # Stream in 1 MB chunks with per-pattern carries. A carry of
+    # len(pattern)-1 bytes can never hold a complete occurrence, so
+    # prepending it to the next chunk catches boundary-spanning matches
+    # without double counting.
+    banner_count = 0
+    marker_found = marker_bytes is None
+    banner_carry = b""
+    marker_carry = b""
     try:
         with open(path, "rb") as f:
-            # Scan the rest in 1 MB chunks; chelpg result block is tiny so a
-            # bounded streaming scan beats slurping a multi-MB progress log.
-            f.seek(8192)
             while True:
                 chunk = f.read(1 << 20)
                 if not chunk:
                     return False
-                if marker.encode("utf-8") in chunk:
+                buf = banner_carry + chunk
+                banner_count += buf.count(_MULTIWFN_MENU_BANNER)
+                banner_carry = buf[len(buf) - (len(_MULTIWFN_MENU_BANNER) - 1):]
+                if not marker_found:
+                    mbuf = marker_carry + chunk
+                    if marker_bytes in mbuf:
+                        marker_found = True
+                    else:
+                        marker_carry = mbuf[len(mbuf) - (len(marker_bytes) - 1):]
+                if banner_count >= _MENU_BANNER_REQUIRED_COUNT and marker_found:
                     return True
     except OSError:
         return False

--- a/qtaim_gen/source/scripts/helpers/sweep_truncated_steps.py
+++ b/qtaim_gen/source/scripts/helpers/sweep_truncated_steps.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Dry-run of the per-sub-job restart skip logic over a job list.
+
+For each folder, replays the exact skip decisions gbw_analysis(restart=True)
+would make (_has_usable_step_output / _compiled_data_present) plus the
+folder-level validation gate, and classifies:
+
+  complete         validation passes; nothing to do
+  needs_rerun      validation fails and >=1 step would re-run
+                   (self-heals on the next --restart pass)
+  validation_loop  validation fails but every step would be skipped --
+                   the folder would requeue forever; needs attention
+  no_outputs       results folder missing or never started (no gbw_analysis.log)
+  error            classification raised an exception
+
+Writes one JSON line per folder to --report_file, prints a summary, and
+optionally writes non-complete folders to --requeue_file.
+
+Example (OMol4M):
+    python -m qtaim_gen.source.scripts.helpers.sweep_truncated_steps \
+        --job_file job_lists/ml_elytes_refined.txt \
+        --root_omol_inputs /p/lustre5/bennion1/Omol2025-4M-DiversitySet/ \
+        --root_omol_results /p/lustre5/vargas58/OMol4M/ \
+        --full_set 1 --n_workers 32 \
+        --report_file sweep_ml_elytes.jsonl
+"""
+import os
+import json
+import argparse
+import concurrent.futures
+from collections import Counter
+from typing import Optional, List
+
+from tqdm import tqdm
+
+from qtaim_gen.source.core.omol import (
+    _compiled_data_present,
+    _has_usable_step_output,
+    _is_substantive_step_out,
+    _wavefunction_present,
+)
+from qtaim_gen.source.data.multiwfn import (
+    bond_order_dict,
+    charge_data_dict,
+    fuzzy_data,
+    other_data_dict,
+)
+from qtaim_gen.source.utils.validation import (
+    get_charge_spin_n_atoms_from_folder,
+    validation_checks,
+)
+
+
+def resolve_results_folder(
+    folder_inputs: str,
+    root_omol_inputs: Optional[str],
+    root_omol_results: Optional[str],
+) -> str:
+    """Map an input folder path to its results location (mirrors get_folders_from_file)."""
+    if (
+        root_omol_inputs
+        and root_omol_results
+        and folder_inputs.startswith(root_omol_inputs)
+    ):
+        rel = folder_inputs[len(root_omol_inputs):].lstrip(os.sep)
+        return os.path.join(root_omol_results, rel)
+    return folder_inputs
+
+
+def routine_sets(full_set: int, spin_tf: bool):
+    """Routine order + compiled_map exactly as run_jobs builds them."""
+    charge = charge_data_dict(full_set)
+    bond = bond_order_dict(full_set)
+    fuzzy = fuzzy_data(spin=spin_tf, full_set=full_set)
+    other = other_data_dict(full_set)
+    compiled_map = {}
+    for op in charge:
+        compiled_map[op] = ("charge.json", op, "charge")
+    for op in bond:
+        compiled_map[op] = ("bond.json", op)
+    for op in fuzzy:
+        compiled_map[op] = ("fuzzy_full.json", op)
+    for op in other:
+        compiled_map[op] = ("other.json", None)
+    order = list(charge) + list(bond) + list(fuzzy) + list(other) + ["qtaim"]
+    return order, compiled_map, set(fuzzy)
+
+
+def classify_folder(
+    folder_inputs: str,
+    root_omol_inputs: Optional[str],
+    root_omol_results: Optional[str],
+    full_set: int,
+    move_results: bool,
+) -> dict:
+    folder = resolve_results_folder(folder_inputs, root_omol_inputs, root_omol_results)
+    rec = {"folder": folder_inputs, "results_folder": folder}
+
+    if not os.path.isdir(folder) or not os.path.exists(
+        os.path.join(folder, "gbw_analysis.log")
+    ):
+        rec["class"] = "no_outputs"
+        return rec
+
+    n_atoms = None
+    spin_tf = False
+    try:
+        dft_dict = get_charge_spin_n_atoms_from_folder(folder)
+        if dft_dict and dft_dict.get("mol"):
+            n_atoms = len(dft_dict["mol"])
+            spin_tf = dft_dict.get("spin", 1) != 1
+    except Exception:
+        pass
+    rec["n_atoms"] = n_atoms
+
+    # workload done so far (restart resumes from here)
+    for base in (os.path.join(folder, "generator"), folder):
+        timings_path = os.path.join(base, "timings.json")
+        try:
+            with open(timings_path, "r") as f:
+                timings = json.load(f)
+            rec["timings_sum_s"] = round(
+                sum(v for v in timings.values() if isinstance(v, (int, float)) and v > 0),
+                1,
+            )
+            break
+        except (OSError, json.JSONDecodeError, AttributeError):
+            continue
+
+    try:
+        valid = bool(
+            validation_checks(
+                folder,
+                full_set=full_set,
+                move_results=move_results,
+                verbose=False,
+                logger=None,
+            )
+        )
+    except Exception:
+        valid = False
+    if valid:
+        rec["class"] = "complete"
+        return rec
+
+    order, compiled_map, fuzzy_routines = routine_sets(full_set, spin_tf)
+    rerun_steps: List[str] = []
+    truncated_steps: List[str] = []
+    for op in order:
+        will_skip = _has_usable_step_output(folder, op) or _compiled_data_present(
+            folder,
+            op,
+            compiled_map,
+            n_atoms=n_atoms,
+            fuzzy_routines=fuzzy_routines,
+        )
+        if will_skip:
+            continue
+        rerun_steps.append(op)
+        for base in (folder, os.path.join(folder, "generator")):
+            out_path = os.path.join(base, f"{op}.out")
+            if os.path.isfile(out_path) and not _is_substantive_step_out(
+                out_path, order=op
+            ):
+                truncated_steps.append(op)
+                break
+
+    rec["rerun_steps"] = rerun_steps
+    rec["truncated_steps"] = truncated_steps
+    rec["wavefunction_present"] = _wavefunction_present(folder)
+    rec["class"] = "needs_rerun" if rerun_steps else "validation_loop"
+    return rec
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sweep-truncated-steps",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--job_file", type=str, required=True,
+                        help="file with one job folder path per line")
+    parser.add_argument("--num_folders", type=int, default=-1,
+                        help="max folders to sweep (-1 = all)")
+    parser.add_argument("--full_set", type=int, default=0,
+                        help="calculation detail level (0/1/2), must match the run")
+    parser.add_argument("--root_omol_inputs", type=str, default=None,
+                        help="input root to strip when mapping to results")
+    parser.add_argument("--root_omol_results", type=str, default=None,
+                        help="results root where job outputs live")
+    parser.add_argument("--move_results", action="store_true",
+                        help="validate against generator/ subfolder (post-move layout)")
+    parser.add_argument("--n_workers", type=int, default=8,
+                        help="parallel workers (I/O bound; default 8)")
+    parser.add_argument("--report_file", type=str, default="sweep_report.jsonl",
+                        help="JSONL output, one record per folder")
+    parser.add_argument("--requeue_file", type=str, default=None,
+                        help="if set, write non-complete folder paths here")
+    args = parser.parse_args(argv)
+
+    with open(args.job_file, "r") as f:
+        folders = [
+            line.strip() for line in f
+            if line.strip() and not line.strip().startswith("#")
+        ]
+    if args.num_folders > 0:
+        folders = folders[: args.num_folders]
+    if not folders:
+        print(f"No folders found in {args.job_file}")
+        return 2
+
+    records = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.n_workers) as ex, \
+            open(args.report_file, "w") as report:
+        futures = {
+            ex.submit(
+                classify_folder,
+                folder,
+                args.root_omol_inputs,
+                args.root_omol_results,
+                args.full_set,
+                args.move_results,
+            ): folder
+            for folder in folders
+        }
+        for future in tqdm(
+            concurrent.futures.as_completed(futures),
+            total=len(futures), desc="Sweeping folders", unit="folder",
+        ):
+            try:
+                rec = future.result()
+            except Exception as e:
+                rec = {
+                    "folder": futures[future],
+                    "class": "error",
+                    "error": f"{type(e).__name__}: {e}",
+                }
+            records.append(rec)
+            report.write(json.dumps(rec) + "\n")
+
+    class_counts = Counter(rec["class"] for rec in records)
+    rerun_counts = Counter(
+        step for rec in records for step in rec.get("rerun_steps", [])
+    )
+    truncated_counts = Counter(
+        step for rec in records for step in rec.get("truncated_steps", [])
+    )
+
+    print("\nFolder classes:")
+    for cls in ("complete", "needs_rerun", "validation_loop", "no_outputs", "error"):
+        if class_counts.get(cls):
+            print(f"  {cls:16s} {class_counts[cls]}")
+    if rerun_counts:
+        print("\nSteps needing rerun (folder counts):")
+        for step, n in rerun_counts.most_common():
+            trunc = truncated_counts.get(step, 0)
+            print(f"  {step:22s} {n:6d}  (truncated .out: {trunc})")
+    big = sorted(
+        (r for r in records if r["class"] == "needs_rerun" and r.get("n_atoms")),
+        key=lambda r: r["n_atoms"], reverse=True,
+    )[:5]
+    if big:
+        print("\nLargest needs_rerun folders (n_atoms):")
+        for r in big:
+            print(f"  {r['n_atoms']:5d} atoms  {r['folder']}")
+    print(f"\nReport: {args.report_file}")
+
+    if args.requeue_file:
+        requeue = [r["folder"] for r in records if r["class"] != "complete"]
+        with open(args.requeue_file, "w") as f:
+            for folder in requeue:
+                f.write(folder + "\n")
+        print(f"Requeue list ({len(requeue)} folders): {args.requeue_file}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_restart_partial_folders.py
+++ b/tests/test_restart_partial_folders.py
@@ -1162,6 +1162,57 @@ class TestSubstantiveStepOut:
 
 
 # ---------------------------------------------------------------------------
+# Tests: parse_multiwfn routine dispatch is exact-match on filename
+# ---------------------------------------------------------------------------
+
+
+# Minimal fuzzy real-space block in the shape parse_fuzzy_real_space expects.
+_FUZZY_REAL_SPACE_BLOCK = (
+    "   Atomic space        Value                % of sum            % of sum abs\n"
+    "     1(C )            6.42104237             0.796657             0.796657\n"
+    "     2(H )            0.79658570             0.098832             0.098832\n"
+    " Summing up all above values:            7.21762807\n"
+    " Summing up absolute value of above values:      7.21762807\n"
+    "\n"
+)
+
+
+class TestParseMultiwfnExactDispatch:
+    """Routine dispatch must exact-match the .out filename. Substring
+    matching parsed becke_fuzzy_density.out under both 'becke' and
+    'becke_fuzzy_density', writing wrong-parser output to the same json
+    that only routine-list order corrected."""
+
+    def test_fuzzy_density_parsed_once_by_right_parser(self, tmp_path, caplog):
+        from qtaim_gen.source.core.omol import parse_multiwfn
+        import logging
+
+        folder = tmp_path / "job"
+        folder.mkdir()
+        (folder / "orca.inp").write_text(
+            "! wB97M-V\n*xyz 0 1\nC 0 0 0\nH 0 0 1\n*\n"
+        )
+        (folder / "becke_fuzzy_density.out").write_text(_FUZZY_REAL_SPACE_BLOCK)
+
+        logger = logging.getLogger("test_exact_dispatch")
+        with caplog.at_level(logging.INFO, logger="test_exact_dispatch"):
+            parse_multiwfn(str(folder), separate=True, full_set=1, logger=logger)
+
+        messages = [r.message for r in caplog.records]
+        assert any(
+            m.startswith("Parsed becke_fuzzy_density output") for m in messages
+        )
+        # the 'becke' charge parser must never touch this file
+        assert not any(m.startswith("Parsed becke output") for m in messages)
+        assert not any(m.startswith("Error parsing becke in") for m in messages)
+
+        with open(folder / "fuzzy_full.json") as f:
+            fuzzy = json.load(f)
+        assert fuzzy["becke_fuzzy_density"]["sum"] == 7.21762807
+        assert fuzzy["becke_fuzzy_density"]["1_C"] == 6.42104237
+
+
+# ---------------------------------------------------------------------------
 # Tests: parse_multiwfn compile loop tolerates empty / malformed intermediates
 # ---------------------------------------------------------------------------
 

--- a/tests/test_restart_partial_folders.py
+++ b/tests/test_restart_partial_folders.py
@@ -1038,10 +1038,21 @@ class TestCompiledDataPresentLengthAware:
 
 
 # Multiwfn 3.8 banner — present in every .out, head-sniff sees it as "clean".
+# Includes the startup main-menu print (first of the two occurrences the
+# generic completion check counts).
 _MULTIWFN_HEAD = (
     " Multiwfn -- A Multifunctional Wavefunction Analyzer\n"
     " Version 3.8(dev), update date: 2024-Oct-6\n"
     " ( Number of parallel threads:   4 )\n"
+    "                    ************ Main function menu ************\n"
+    " 0 Show molecular structure and view orbitals\n"
+)
+
+# Re-printed main menu after the script's final "0" return — the second
+# banner occurrence that marks a completed run.
+_MULTIWFN_MENU_TAIL = (
+    "                    ************ Main function menu ************\n"
+    " 300 Other functions (Part 3)\n"
 )
 
 # Realistic chelpg progress lines — no result table, run was killed.
@@ -1055,8 +1066,10 @@ _CHELPG_TRUNCATED_TAIL = (
 
 
 class TestSubstantiveStepOut:
-    """`_is_substantive_step_out` must reject chelpg.out files that lack the
-    'Center       Charge' completion marker, even if the head looks clean."""
+    """`_is_substantive_step_out` must reject .out files from runs killed
+    mid-computation. Generic signal: the main-menu banner must appear twice
+    (startup + final return-to-main). chelpg additionally requires the
+    'Center       Charge' result marker."""
 
     def test_chelpg_truncated_rejected(self, tmp_path):
         """chelpg killed mid-ESP: clean head, no result table → not substantive."""
@@ -1067,7 +1080,7 @@ class TestSubstantiveStepOut:
         assert not _is_substantive_step_out(str(path), order="chelpg")
 
     def test_chelpg_complete_accepted(self, tmp_path):
-        """chelpg with the 'Center       Charge' marker is accepted."""
+        """chelpg with the result marker and both menu prints is accepted."""
         from qtaim_gen.source.core.omol import _is_substantive_step_out
 
         path = tmp_path / "chelpg.out"
@@ -1076,25 +1089,63 @@ class TestSubstantiveStepOut:
             + _CHELPG_TRUNCATED_TAIL
             + "\n  Center       Charge\n"
             + " Atom    1(C ): -0.123456\n"
+            + _MULTIWFN_MENU_TAIL
         )
         path.write_text(body)
         assert _is_substantive_step_out(str(path), order="chelpg")
 
-    def test_chelpg_marker_in_head_accepted(self, tmp_path):
-        """Marker landing inside the first 8 KB short-circuits the tail scan."""
+    def test_chelpg_marker_without_second_menu_rejected(self, tmp_path):
+        """Killed between the result table and the menu return → rejected."""
         from qtaim_gen.source.core.omol import _is_substantive_step_out
 
         path = tmp_path / "chelpg.out"
         path.write_text(_MULTIWFN_HEAD + " Center       Charge\n")
-        assert _is_substantive_step_out(str(path), order="chelpg")
+        assert not _is_substantive_step_out(str(path), order="chelpg")
 
-    def test_unknown_routine_keeps_legacy_behavior(self, tmp_path):
-        """Routines without a registered marker keep the head-only check."""
+    def test_generic_truncated_rejected(self, tmp_path):
+        """Any routine killed mid-progress (one banner only) → rejected.
+
+        This is the elytes 274-atom edge case: elf_fuzzy.out truncated at
+        38% progress passed the old head-only check and was skipped forever.
+        """
+        from qtaim_gen.source.core.omol import _is_substantive_step_out
+
+        path = tmp_path / "elf_fuzzy.out"
+        path.write_text(
+            _MULTIWFN_HEAD
+            + " Radial points:   75    Angular points:  434\n"
+            + " Progress: [####----------------]  38.0 %\n"
+        )
+        assert not _is_substantive_step_out(str(path), order="elf_fuzzy")
+
+    def test_generic_complete_accepted(self, tmp_path):
+        """Routine without a registered marker: two banners suffice."""
         from qtaim_gen.source.core.omol import _is_substantive_step_out
 
         path = tmp_path / "hirshfeld.out"
-        path.write_text(_MULTIWFN_HEAD + "some content\n")
+        path.write_text(
+            _MULTIWFN_HEAD
+            + " Final atomic charges:\n"
+            + " Atom    1(C ): -0.123456\n"
+            + _MULTIWFN_MENU_TAIL
+        )
         assert _is_substantive_step_out(str(path), order="hirshfeld")
+
+    def test_second_banner_spanning_chunk_boundary_accepted(self, tmp_path):
+        """A second banner that straddles the 1 MB read boundary is found
+        via the carry, not double counted, and accepted."""
+        from qtaim_gen.source.core.omol import (
+            _MULTIWFN_MENU_BANNER,
+            _is_substantive_step_out,
+        )
+
+        path = tmp_path / "mbis_fuzzy_density.out"
+        head = _MULTIWFN_HEAD.encode()
+        # Banner is 18 bytes; start it 9 bytes before the 1 MB boundary so
+        # it spans the first and second read chunks.
+        pad = b"x" * ((1 << 20) - 9 - len(head))
+        path.write_bytes(head + pad + _MULTIWFN_MENU_BANNER + b"\n")
+        assert _is_substantive_step_out(str(path), order="mbis_fuzzy_density")
 
     def test_error_signature_still_rejected(self, tmp_path):
         """A multiwfn error signature in the head trumps everything."""
@@ -1105,6 +1156,7 @@ class TestSubstantiveStepOut:
             _MULTIWFN_HEAD
             + " Error: Unable to find input file\n"
             + " Center       Charge\n"  # marker present but error wins
+            + _MULTIWFN_MENU_TAIL      # second banner present but error wins
         )
         assert not _is_substantive_step_out(str(path), order="chelpg")
 

--- a/tests/test_sweep_truncated_steps.py
+++ b/tests/test_sweep_truncated_steps.py
@@ -1,0 +1,179 @@
+"""Tests for the restart-skip dry-run sweep (sweep_truncated_steps helper)."""
+import json
+
+import pytest
+
+from qtaim_gen.source.scripts.helpers import sweep_truncated_steps as sweep
+
+
+_ORCA_INP = (
+    "! wB97M-V def2-TZVPD EnGrad\n"
+    "*xyz 0 1 \n"
+    "C   0.000 0.000 0.000\n"
+    "O   0.000 0.000 1.200\n"
+    "H   0.900 0.000 -0.500\n"
+    "*\n"
+)
+
+_MULTIWFN_HEAD = (
+    " Multiwfn -- A Multifunctional Wavefunction Analyzer\n"
+    "                    ************ Main function menu ************\n"
+)
+
+_MULTIWFN_MENU_TAIL = (
+    "                    ************ Main function menu ************\n"
+)
+
+
+def _make_started_folder(tmp_path):
+    """Folder that has begun processing: log + orca.inp present."""
+    folder = tmp_path / "job"
+    folder.mkdir()
+    (folder / "gbw_analysis.log").write_text("started\n")
+    (folder / "orca.inp").write_text(_ORCA_INP)
+    return folder
+
+
+class TestResolveResultsFolder:
+    def test_mapping_applied(self):
+        out = sweep.resolve_results_folder(
+            "/inputs/cat/job_1", "/inputs", "/results"
+        )
+        assert out == "/results/cat/job_1"
+
+    def test_passthrough_without_roots(self):
+        assert sweep.resolve_results_folder("/x/job", None, None) == "/x/job"
+
+    def test_passthrough_when_prefix_mismatch(self):
+        assert (
+            sweep.resolve_results_folder("/other/job", "/inputs", "/results")
+            == "/other/job"
+        )
+
+
+class TestRoutineSets:
+    def test_full_set_1_contains_extended_routines(self):
+        order, compiled_map, fuzzy_routines = sweep.routine_sets(1, spin_tf=False)
+        for op in ("vdd", "chelpg", "mbis", "elf_fuzzy", "mbis_fuzzy_density", "qtaim"):
+            assert op in order
+        assert compiled_map["vdd"] == ("charge.json", "vdd", "charge")
+        assert compiled_map["ibsi_bond"] == ("bond.json", "ibsi_bond")
+        assert compiled_map["elf_fuzzy"] == ("fuzzy_full.json", "elf_fuzzy")
+        assert compiled_map["other_alie"] == ("other.json", None)
+        assert "elf_fuzzy" in fuzzy_routines
+        assert "qtaim" not in compiled_map
+
+    def test_spin_adds_spin_routines(self):
+        order, _, fuzzy_routines = sweep.routine_sets(1, spin_tf=True)
+        assert "hirsh_fuzzy_spin" in order
+        assert "mbis_fuzzy_spin" in fuzzy_routines
+
+
+class TestClassifyFolder:
+    def test_no_outputs_when_folder_missing(self, tmp_path):
+        rec = sweep.classify_folder(
+            str(tmp_path / "absent"), None, None, full_set=1, move_results=False
+        )
+        assert rec["class"] == "no_outputs"
+
+    def test_no_outputs_without_log(self, tmp_path):
+        folder = tmp_path / "job"
+        folder.mkdir()
+        rec = sweep.classify_folder(
+            str(folder), None, None, full_set=1, move_results=False
+        )
+        assert rec["class"] == "no_outputs"
+
+    def test_complete_when_validation_passes(self, tmp_path, monkeypatch):
+        folder = _make_started_folder(tmp_path)
+        monkeypatch.setattr(sweep, "validation_checks", lambda *a, **k: True)
+        rec = sweep.classify_folder(
+            str(folder), None, None, full_set=1, move_results=False
+        )
+        assert rec["class"] == "complete"
+        assert rec["n_atoms"] == 3
+
+    def test_validation_loop_when_all_steps_skip(self, tmp_path, monkeypatch):
+        """Validation fails but every step looks skippable -- the stuck class."""
+        folder = _make_started_folder(tmp_path)
+        monkeypatch.setattr(sweep, "validation_checks", lambda *a, **k: False)
+        monkeypatch.setattr(sweep, "_has_usable_step_output", lambda *a, **k: True)
+        rec = sweep.classify_folder(
+            str(folder), None, None, full_set=1, move_results=False
+        )
+        assert rec["class"] == "validation_loop"
+        assert rec["rerun_steps"] == []
+
+    def test_needs_rerun_flags_truncated_out(self, tmp_path):
+        """Real files, no mocks: truncated elf_fuzzy.out (one banner) must be
+        classified needs_rerun with elf_fuzzy in truncated_steps."""
+        folder = _make_started_folder(tmp_path)
+        (folder / "elf_fuzzy.out").write_text(
+            _MULTIWFN_HEAD + " Progress: [####------]  38.0 %\n"
+        )
+        rec = sweep.classify_folder(
+            str(folder), None, None, full_set=1, move_results=False
+        )
+        assert rec["class"] == "needs_rerun"
+        assert "elf_fuzzy" in rec["rerun_steps"]
+        assert "elf_fuzzy" in rec["truncated_steps"]
+        # steps with no artifacts at all rerun but are not "truncated"
+        assert "hirshfeld" in rec["rerun_steps"]
+        assert "hirshfeld" not in rec["truncated_steps"]
+
+    def test_complete_out_not_rerun(self, tmp_path):
+        """A .out with two banners is trusted; the step is skipped."""
+        folder = _make_started_folder(tmp_path)
+        (folder / "hirshfeld.out").write_text(
+            _MULTIWFN_HEAD
+            + " Final atomic charges:\n"
+            + _MULTIWFN_MENU_TAIL
+        )
+        rec = sweep.classify_folder(
+            str(folder), None, None, full_set=1, move_results=False
+        )
+        assert rec["class"] == "needs_rerun"
+        assert "hirshfeld" not in rec["rerun_steps"]
+
+    def test_timings_sum_reported(self, tmp_path):
+        folder = _make_started_folder(tmp_path)
+        (folder / "timings.json").write_text(
+            json.dumps({"qtaim": 100.0, "hirshfeld": 50.0, "adch": -1})
+        )
+        rec = sweep.classify_folder(
+            str(folder), None, None, full_set=1, move_results=False
+        )
+        assert rec["timings_sum_s"] == 150.0
+
+
+class TestMainCli:
+    def test_end_to_end_report_and_requeue(self, tmp_path):
+        folder = _make_started_folder(tmp_path)
+        (folder / "elf_fuzzy.out").write_text(
+            _MULTIWFN_HEAD + " Progress: [##--------]  20.0 %\n"
+        )
+        job_file = tmp_path / "jobs.txt"
+        job_file.write_text(f"# comment\n\n{folder}\n")
+        report = tmp_path / "report.jsonl"
+        requeue = tmp_path / "requeue.txt"
+        rc = sweep.main([
+            "--job_file", str(job_file),
+            "--full_set", "1",
+            "--report_file", str(report),
+            "--requeue_file", str(requeue),
+            "--n_workers", "2",
+        ])
+        assert rc == 0
+        recs = [json.loads(line) for line in report.read_text().splitlines()]
+        assert len(recs) == 1
+        assert recs[0]["class"] == "needs_rerun"
+        assert requeue.read_text().strip() == str(folder)
+
+    def test_empty_job_file_returns_2(self, tmp_path):
+        job_file = tmp_path / "jobs.txt"
+        job_file.write_text("# only a comment\n")
+        rc = sweep.main([
+            "--job_file", str(job_file),
+            "--report_file", str(tmp_path / "r.jsonl"),
+        ])
+        assert rc == 2


### PR DESCRIPTION
This pull request introduces several important improvements to result file validation and job recovery logic, focusing on preventing silent data corruption, improving detection of incomplete computation outputs, and adding new utilities for analyzing job folder states. The changes include a new generic completion check for Multiwfn `.out` files, stricter validation of scalers, and a new script for sweeping and classifying job folders. Test coverage is also updated to reflect the new logic.

**Result file validation and job recovery:**

* [`qtaim_gen/source/core/omol.py`](diffhunk://#diff-8b607a34c6802609b4d9273e2a16271706d945191a455fbe3749bc808ba2f80eR1653-R1679): The logic for detecting successful Multiwfn runs is now more robust and generic. Instead of relying only on routine-specific markers, the code now requires that the main-menu banner appears twice in the `.out` file (at startup and after successful completion). This prevents truncated/incomplete runs from being misclassified as successful, fixing cases where jobs could be skipped forever due to partial output. [[1]](diffhunk://#diff-8b607a34c6802609b4d9273e2a16271706d945191a455fbe3749bc808ba2f80eR1653-R1679) [[2]](diffhunk://#diff-8b607a34c6802609b4d9273e2a16271706d945191a455fbe3749bc808ba2f80eL1676-R1720)
* [`qtaim_gen/source/core/omol.py`](diffhunk://#diff-8b607a34c6802609b4d9273e2a16271706d945191a455fbe3749bc808ba2f80eL782-R786): The routine matching in `parse_multiwfn` now requires exact filename matches, preventing double-parsing and incorrect output for routines with similar names.

**Data integrity and scaling:**

* [`qtaim_gen/source/core/converter.py`](diffhunk://#diff-c1b5c4b4939eb1771f87dbdfcbf78c2183038a8811dace5642a1f8626b370dfcR130-R162): Introduced `_validate_and_log_scaler`, which logs per-node-type statistics and raises an error if a scaler has zero or non-finite standard deviations. This ensures that broken scalers (which would otherwise silently write Inf/NaN into every graph) are caught early. The validation is integrated into the `merge_shards` workflow. [[1]](diffhunk://#diff-c1b5c4b4939eb1771f87dbdfcbf78c2183038a8811dace5642a1f8626b370dfcR130-R162) [[2]](diffhunk://#diff-c1b5c4b4939eb1771f87dbdfcbf78c2183038a8811dace5642a1f8626b370dfcR1011-R1017)
* [`qtaim_gen/source/core/converter.py`](diffhunk://#diff-c1b5c4b4939eb1771f87dbdfcbf78c2183038a8811dace5642a1f8626b370dfcR1053): When scalers are applied, a "scaled" flag is now written to the LMDB, improving downstream tracking.

**Testing and utilities:**

* [`tests/test_restart_partial_folders.py`](diffhunk://#diff-baa223856462d489acbf7f86cc1cf8885fd9e0e965dc269194a7f900cb5c73f1R1041-R1055): The test suite for output file detection is updated to reflect the new generic completion check, including cases for truncated outputs, chunk boundary handling, and routines with/without specific markers. [[1]](diffhunk://#diff-baa223856462d489acbf7f86cc1cf8885fd9e0e965dc269194a7f900cb5c73f1R1041-R1055) [[2]](diffhunk://#diff-baa223856462d489acbf7f86cc1cf8885fd9e0e965dc269194a7f900cb5c73f1L1058-R1072) [[3]](diffhunk://#diff-baa223856462d489acbf7f86cc1cf8885fd9e0e965dc269194a7f900cb5c73f1L1070-R1083) [[4]](diffhunk://#diff-baa223856462d489acbf7f86cc1cf8885fd9e0e965dc269194a7f900cb5c73f1R1092-R1149)
* [`qtaim_gen/source/scripts/helpers/sweep_truncated_steps.py`](diffhunk://#diff-5f2ced8a23b0686e12d85550cfa5879c95d05fbf4186a490bbc9299b6ad9b92aR1-R279): Added a new script that analyzes job folders to classify their state (complete, needs rerun, validation loop, no outputs, error), reporting on steps needing rerun and optionally producing a requeue list. This tool helps identify and recover from incomplete or stuck jobs.